### PR TITLE
feat(tasks): add build, launch, debugger tasks for test-project

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,8 +47,6 @@
 
 				"editor.guides.bracketPairs": "active",
 
-				"scm.defaultViewMode": "tree",
-				"remote.containers.copyGitConfig": true,
 				"debug.internalConsoleOptions": "neverOpen",
 
 				"files.watcherExclude": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,13 +42,13 @@
 		// Configure properties specific to VS Code.
 		"vscode": {
 			"settings": {
-				"workbench.colorTheme": "Visual Studio 2019 Dark",
 				"terminal.integrated.defaultProfile.linux": "zsh",
 				"editor.formatOnPaste": true,
 
 				"editor.guides.bracketPairs": "active",
 
 				"scm.defaultViewMode": "tree",
+				"remote.containers.copyGitConfig": true,
 				"debug.internalConsoleOptions": "neverOpen",
 
 				"files.watcherExclude": {
@@ -73,13 +73,10 @@
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
-				"github.vscode-pull-request-github",
-
 				"visualstudioexptteam.vscodeintellicode",
 				"visualstudiotxptteam.vscodeintellicode-completions",
 				"ms-dotnettools.csharp",
 				"ms-dotnettools.vscode-dotnet-runtime",
-				"ms-edgedevtools.vscode-edge-devtools",
 				
 				"humao.rest-client",
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 
 	"containerEnv": {
 		// Set ASP.NET environment settings.
-		"ASPNETCORE_URLS": "https://+:7071;http://+:7070",
+		"ASPNETCORE_URLS": "https://+:5001;http://+:5000",
 		"ASPNETCORE_ENVIRONMENT": "Development",
 		// Set dotnet CLI environment settings.
 		"DOTNET_CLI_TELEMETRY_OPTOUT": "1",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/test-project/bin/Debug/net6.0/test-project.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/test-project/",
+            "stopAtEntry": false,
+            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            }
+        },
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,48 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "clean",
+            "command": "dotnet",
+            "args": [
+                "clean",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/test-project/"
+            },
+            "type": "process",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "args": [
+                "build",
+                "${workspaceFolder}/test-project/",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "dependsOn": "clean",
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/test-project/"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ This template repo serves as a flavor of quick-starter development container for
 [gh-codespaces-quickstart]: https://docs.github.com/en/codespaces/getting-started/quickstart
 [dotnet-quickstart]: https://www.youtube.com/playlist?list=PLdo4fOcmZ0oUc2ShrReCS7KoBbPEONE0p
 
-
-
 ### What's in it:
 
 - .NET 6.0 SDK and Runtime

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ This template repo serves as a flavor of quick-starter development container for
 - ZSH integrated Terminal
 - Docker CLI with Compose v2
 
-
-
 ## Using This Template
 
 If you are completely new to .NET, [Awesome .NET discussion][awesome-list-dotnet] is a good source to start with.
@@ -57,7 +55,7 @@ If you have any technical problems with GitHub Codespaces or dev containers, you
 
 ## Contributing
 
-The official repo to contribute would be [@microsoft/vscode-dev-containers][contrib-official-repo]. 
+The official repo to contribute would be [@microsoft/vscode-dev-containers][contrib-official-repo].
 
 Have a suggestion or a bug fix? Just open a pull request or an issue. Include the development container with clear and simplest instructions possible.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,43 @@ First, you want to ensure source code is Reopened in Container. Then you'll be a
 With VS Code:
 
 1. In a terminal, run `dotnet --list-sdks` to verify required versions are installed.
-3. Run `az --version` to verify Azure CLI version is 2.4 or above.
+3. Run `gh --version` to verify GitHub CLI is installed.
+
+### Create a minimal api
+
+Next, you would want to create a .net project, say, a minimal web api `test-project` that ships with .net template projects.
+
+With VS Code:
+
+1. Run the `dotnet new` command to create a web api with specific template.
+
+   ```bash
+   dotnet new webapi -o test-project \
+                     --use-minimal-apis \
+                     --language "C#"
+   ```
+
+2. Open the launchSettings.json, then change the `test_project` profile to run on port `5000` for HTTP and `5001` for HTTPS.
+
+   ```json
+   "profiles": {
+     "test_project": {
+       // ...
+       "applicationUrl": "https://localhost:5001;http://localhost:5000",
+       // ...
+   }
+   ```
+
+### Build and run from source
+
+VS Code is integrated with the Omnisharp Tools to run the web api on the local development computer, in this case, its this dev container.
+
+With VS Code:
+
+1. Press `F5` to start the web api project and call the swagger endpoint. The terminal displays the output from the Debug Console.
+2. When the web api executes locally, your favorite browser will launch the https://localhost:5001.
+3. Visit https://localhost:5001/swagger
+4. Press `Ctrl+C` to stop disconnect the debugger.
 
 
 

--- a/README.md
+++ b/README.md
@@ -48,15 +48,12 @@ Next, you would want to create a .net project, say, a minimal web api `test-proj
 With VS Code:
 
 1. Run the `dotnet new` command to create a web api with specific template.
-
    ```bash
    dotnet new webapi -o test-project \
                      --use-minimal-apis \
                      --language "C#"
    ```
-
 2. Open the launchSettings.json, then change the `test_project` profile to run on port `5000` for HTTP and `5001` for HTTPS.
-
    ```json
    "profiles": {
      "test_project": {
@@ -78,13 +75,11 @@ With VS Code:
 4. Press `Ctrl+C` to stop disconnect the debugger.
 
 
-
 ## Feedback
 
 If you have any technical problems with GitHub Codespaces or dev containers, you are better off asking [VS Code Support][feedback-channels] directly, since you'll end up getting a much faster response back that way.
 
 [feedback-channels]: https://github.com/microsoft/vscode-dev-containers#contributing-and-feedback
-
 
 
 ## Contributing
@@ -94,7 +89,6 @@ The official repo to contribute would be [@microsoft/vscode-dev-containers][cont
 Have a suggestion or a bug fix? Just open a pull request or an issue. Include the development container with clear and simplest instructions possible.
 
 [contrib-official-repo]: https://github.com/microsoft/vscode-dev-containers#readme
-
 
 
 ## License


### PR DESCRIPTION
this changeset is to add vs code tasks and launch configurations to build, run, and debug a web project.

- change the default port to 5000-5001
- clean up dev container vs code settings
- add tasks.json to clean, build, and run test-project
- add launch.json to run from the source
- update docs with things to try with this container